### PR TITLE
change path to relative on get_filename_component()

### DIFF
--- a/impl/asset/client/cpp/CMakeLists.txt
+++ b/impl/asset/client/cpp/CMakeLists.txt
@@ -59,7 +59,7 @@ else()
 endif()
 
 # Proto file
-get_filename_component(hakoniwa_proto "/root/hakoniwa-core/spec/hakoniwa_core.proto" ABSOLUTE)
+get_filename_component(hakoniwa_proto "../../../../spec/hakoniwa_core.proto" ABSOLUTE)
 get_filename_component(hakoniwa_proto_path "${hakoniwa_proto}" PATH)
 
 # Generated sources


### PR DESCRIPTION
CMakeLists.txt 内で絶対パスが記載されていて使いにくかったので，相対パスに変更しました．