### PR TITLE
Supported hakoniwa nogrp by docker

### DIFF
--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -11,7 +11,7 @@ jobs:
     - uses: actions/checkout@v2
     - name: Get DateTime
       id: date
-      run: echo "::set-output name=date::$(date +'%Y%m%d%H%M%S')"
+      run: echo "date=$(date +'%Y%m%d%H%M%S')" >> $GITHUB_OUTPUT
     - name: Build
       run: |
         bash ./impl/asset/server/csharp/HakoniwaCore/build_by_docker.bash Rebuild Debug
@@ -26,3 +26,6 @@ jobs:
           dst/Hakoniwa.deps.json
           dst/Hakoniwa.dll
           dst/Hakoniwa.pdb
+          dst/Hakoniwa_NoGRPC.deps.json
+          dst/Hakoniwa_NoGRPC.dll
+          dst/Hakoniwa_NoGRPC.pdb

--- a/impl/asset/server/csharp/HakoniwaCore/build_by_docker.bash
+++ b/impl/asset/server/csharp/HakoniwaCore/build_by_docker.bash
@@ -24,12 +24,15 @@ if [ "$command" = Rebuild ]; then
     cp -rf ./hakoniwa-core ./.hakoniwa-core
     dotnet restore ./.hakoniwa-core/impl/asset/server/csharp/HakoniwaCore/Hakoniwa.csproj
     dotnet build --configuration ${target} --output /hakoniwa-core/dst ./.hakoniwa-core/impl/asset/server/csharp/HakoniwaCore/Hakoniwa.csproj
+    dotnet restore ./.hakoniwa-core/impl/asset/server/csharp/HakoniwaCore/Hakoniwa_NoGRPC.csproj
+    dotnet build --configuration ${target} --output /hakoniwa-core/dst ./.hakoniwa-core/impl/asset/server/csharp/HakoniwaCore/Hakoniwa_NoGRPC.csproj
     "
 elif [ "$command" = Build ]; then
   docker start hakoniwa-core-builder
   docker exec -it hakoniwa-core-builder /bin/bash -c "
     cp -rf ./hakoniwa-core ./.hakoniwa-core
     dotnet build --configuration ${target} --output /hakoniwa-core/dst ./.hakoniwa-core/impl/asset/server/csharp/HakoniwaCore/Hakoniwa.csproj
+    dotnet build --configuration ${target} --output /hakoniwa-core/dst ./.hakoniwa-core/impl/asset/server/csharp/HakoniwaCore/Hakoniwa_NoGRPC.csproj
     "
 else
   echo "Invalid Command type. You can use {Rebuild|Build}."


### PR DESCRIPTION
- Github Actionsで Hakoniwa_NoGRPC.dllをビルドするように追加しました
- `Get DateTime` において `set-output`がdeprecateされるようなので、修正しました
　　　- [GitHub Actions: Deprecating save-state and set-output commands](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/)